### PR TITLE
add file 'package-lock.json' created by npm install to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 test/unit/coverage
 
 # Editor directories and files


### PR DESCRIPTION
Tracking this file is unnecessary. 